### PR TITLE
Closes #1 - replacing mysql datasource by internal H2 datasource

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,10 +7,17 @@ spring:
   application:
     name: visualizer
   datasource:
-    url: jdbc:mysql://localhost:3306/test
-    username: root
-    password: root
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password: password
+    # alternative datasource: external mysql database example
+#    url: jdbc:mysql://localhost:3306/test
+#    username: root
+#    password: root
+
   jpa:
+    # remove the next line, if you use mysql:
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: update
 


### PR DESCRIPTION
This is how the 500 error could be resolved, if you do not want to use an external mysql database instead.